### PR TITLE
Only retrieve PlayerCharacter when necessary

### DIFF
--- a/src/Wowthing.Backend/Wowthing.Backend.csproj
+++ b/src/Wowthing.Backend/Wowthing.Backend.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
     <PackageReference Include="YamlDotNet" Version="11.1.1" />
     <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="5.1.37" />
+    <PackageReference Include="Zack.EFCore.Batch.Npgsql" Version="1.4.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wowthing.Lib/Contexts/WowDbContext.cs
+++ b/src/Wowthing.Lib/Contexts/WowDbContext.cs
@@ -62,6 +62,7 @@ namespace Wowthing.Lib.Contexts
                 optionsBuilder.UseNpgsql(_connectionString);
             }
             optionsBuilder.UseSnakeCaseNamingConvention();
+            optionsBuilder.UseBatchEF_Npgsql();
         }
 
         protected override void OnModelCreating(ModelBuilder builder)

--- a/src/Wowthing.Lib/Wowthing.Lib.csproj
+++ b/src/Wowthing.Lib/Wowthing.Lib.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.6" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
     <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="5.1.37" />
+    <PackageReference Include="Zack.EFCore.Batch.Npgsql" Version="1.4.6" />
   </ItemGroup>
 
 </Project>

--- a/src/Wowthing.Web/Wowthing.Web.csproj
+++ b/src/Wowthing.Web/Wowthing.Web.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="5.0.6" />
+    <PackageReference Include="Zack.EFCore.Batch.Npgsql" Version="1.4.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
PlayerCharacterJob was retrieving the full PlayerCharacter object before making the API request, most of the time that is going to return a 304 Not Modified response. Change the order to retrieve it AFTER the API request succeeds. Also adds yet another EF Core extension library to do updates without loading the entire object first.