### PR TITLE
Shadowlands Season 2 updates

### DIFF
--- a/frontend/data/constants.ts
+++ b/frontend/data/constants.ts
@@ -1,7 +1,7 @@
 export abstract class Constants {
     static readonly characterMaxLevel: number = 60
-    static readonly maxTorghastWing: number = 9
-    static readonly mythicPlusSeason: number = 5
+    static readonly maxTorghastWing: number = 10
+    static readonly mythicPlusSeason: number = 6
 
     static readonly icons = {
         resting: 'spell/140430', // Passed Out

--- a/frontend/data/dungeon.ts
+++ b/frontend/data/dungeon.ts
@@ -25,6 +25,7 @@ export const affixMap: Dictionary<MythicPlusAffix> = {
     119: new MythicPlusAffix('Beguiling'), // BfA S3
     120: new MythicPlusAffix('Awakened'), // BfA S4
     121: new MythicPlusAffix('Prideful'), // SL S1
+    128: new MythicPlusAffix('Tormented'), // SL S2
 }
 
 export const dungeonMap: Dictionary<Dungeon> = {
@@ -164,6 +165,7 @@ export const seasonMap: Dictionary<MythicPlusSeason> = {
         orderBattleForAzeroth2,
     ]),
     5: new MythicPlusSeason(5, 60, [orderShadowlands]),
+    6: new MythicPlusSeason(6, 60, [orderShadowlands]),
 }
 
 export const badgeToClass: Dictionary<string> = {
@@ -176,13 +178,13 @@ export const badgeToClass: Dictionary<string> = {
 
 // [key level, item level] first match >= key is used
 export const keyVaultItemLevel: Array<Array<number>> = [
-    [14, 226],
-    [12, 223],
-    [10, 220],
-    [8, 216],
-    [7, 213],
-    [5, 210],
-    [4, 207],
-    [3, 203],
-    [2, 200],
+    [15, 252],
+    [14, 249],
+    [12, 246],
+    [11, 242],
+    [10, 239],
+    [8, 236],
+    [7, 233],
+    [5, 229],
+    [2, 226],
 ]

--- a/frontend/data/item-level-quality.ts
+++ b/frontend/data/item-level-quality.ts
@@ -1,0 +1,7 @@
+export const itemLevelQuality: number[][] = [
+    [252, 5], // Mythic raid = 252/259, +15 vault = 252
+    [239, 4], // Heroic raid = 239/246, +10 vault = 239
+    [226, 3], // Normal raid = 226/233, + 2 vault = 226
+    [213, 2], // LFR raid    = 213/220
+    [200, 1], //
+]

--- a/frontend/utils/get-item-level-quality.ts
+++ b/frontend/utils/get-item-level-quality.ts
@@ -1,10 +1,11 @@
-// 226 = mythic  5
-// 213 = heroic  4
-// 200 = normal  3
-// 187 = lfr     2
-// 174 = ?       1
-// 161 = ?       0
+import {itemLevelQuality} from '@/data/item-level-quality'
 
 export default function getItemLevelQuality(itemLevel: number): number {
-    return Math.floor(Math.max(0, Math.min(6, (itemLevel - 148) / 13)))
+    for (const [minItemLevel, quality] of itemLevelQuality) {
+        if (itemLevel >= minItemLevel) {
+            return quality
+        }
+    }
+
+    return 0
 }

--- a/src/Wowthing.Backend/Models/API/NonBlizzard/ApiCharacterRaiderIo.cs
+++ b/src/Wowthing.Backend/Models/API/NonBlizzard/ApiCharacterRaiderIo.cs
@@ -18,6 +18,7 @@ namespace Wowthing.Backend.Models.API.NonBlizzard
             { "season-bfa-3", 3 },
             { "season-bfa-4", 4 },
             { "season-sl-1", 5 },
+            { "season-sl-2", 6 },
         };
 
         public string Season { get; set; }


### PR DESCRIPTION
- Add Tormented affix
- Add SL season 2 to M+
- Update vault item levels
- Move `getItemLevelQuality` values to a lookup table