### PR TITLE
FIx data job issues

### DIFF
--- a/src/Wowthing.Backend/Jobs/Data/DataMythicKeystoneSeasonIndexJob.cs
+++ b/src/Wowthing.Backend/Jobs/Data/DataMythicKeystoneSeasonIndexJob.cs
@@ -30,11 +30,7 @@ namespace Wowthing.Backend.Jobs.Data
             {
                 // Fetch API data
                 var uri = GenerateUri(region, ApiNamespace.Dynamic, ApiPath);
-                var result = await GetJson<ApiDataMythicKeystoneSeasonIndex>(uri);
-                if (result.NotModified)
-                {
-                    return;
-                }
+                var result = await GetJson<ApiDataMythicKeystoneSeasonIndex>(uri, useLastModified: false);
 
                 foreach (var apiSeason in result.Data.Seasons)
                 {

--- a/src/Wowthing.Backend/Jobs/Data/DataRealmIndexJob.cs
+++ b/src/Wowthing.Backend/Jobs/Data/DataRealmIndexJob.cs
@@ -30,11 +30,7 @@ namespace Wowthing.Backend.Jobs.Data
             {
                 // Fetch API data
                 var uri = GenerateUri(region, ApiNamespace.Dynamic, ApiPath);
-                var result = await GetJson<ApiDataRealmIndex>(uri);
-                if (result.NotModified)
-                {
-                    continue;
-                }
+                var result = await GetJson<ApiDataRealmIndex>(uri, useLastModified: false);
 
                 foreach (var apiRealm in result.Data.Realms)
                 {


### PR DESCRIPTION
Some things have been weird due to missing seasons/periods, turns out it's just more entries in the tome of This API Sure Does Suck

- Only spawn DataMythicKeystonePeriod jobs for new periods
- Don't use Last-Modified for some data jobs, the Blizzard API _lies_