### PR TITLE
Add a link to the addon on the upload page.

### DIFF
--- a/src/Wowthing.Web/Views/Upload/Index.cshtml
+++ b/src/Wowthing.Web/Views/Upload/Index.cshtml
@@ -10,6 +10,9 @@
                     Upload your "WoWthing_Collector.lua" file, you can find this in your
                     "World of Warcraft\_retail_\WTF\Account\$AccountName$\SavedVariables\" directory.
                 </p>
+                <p>
+                    The <a href="https://curseforge.com/wow/addons/wowthing-collector">WoWthing_Collector</a> addon is required to create this file.
+                </p>
                 <input type="file" name="luaFile" />
             </div>
         </div>


### PR DESCRIPTION
I was looking for ages for a link to the addon. It was counterintuitive to only have this linked on the home page.