### PR TITLE
Update unavailable.yml

### DIFF
--- a/data/mounts/unavailable/unavailable.yml
+++ b/data/mounts/unavailable/unavailable.yml
@@ -36,13 +36,9 @@ groups:
 
 - name: Promotions
   things:
-  - 58983 # Big Blizzard Bear (Blizzcon)
-  - 281554 # Meat Wagon (Warcraft III: Reforged Spoils of War Edition)
   - 232405 # Primal Flamesaber (Heroes of the Storm)
   - 107516 107517 # Spectral Gryphon/Spectral Wind Rider (Scroll of Resurrection)
-  - 245723 245725 # Stormwind Skychaser/Orgrimmar Interceptor (Blizzcon 2017)
   - 107203 # Tyrael's Charger (Annual Pass)
-  - 294197 # Obsidian Worldbreaker (15th anniversary event)
 
 - name: Recruit-A-Friend
   things:


### PR DESCRIPTION
The removed mounts are available through money. Obsidian Worldbreaker is available from BMAH.