### PR TITLE
Update upgrades.yml

### DIFF
--- a/data/progress/08-shadowlands/upgrades.yml
+++ b/data/progress/08-shadowlands/upgrades.yml
@@ -227,7 +227,7 @@ groups:
       - name: "Empowered Perseverance"
         id: 461 1785
         type: garrisonTree
-        value: 3
+        value: 2
 
       - name: "Discovered Cache"
         id: 461 1792


### PR DESCRIPTION
Fix the number of upgrade points for Empowered Perseverance.  This fixes #721.