### PR TITLE
Create fieldmaster_emberath.yml

### DIFF
--- a/data/_shared/vendor/09-dragonflight/valdrakken/fieldmaster_emberath.yml
+++ b/data/_shared/vendor/09-dragonflight/valdrakken/fieldmaster_emberath.yml
@@ -3,7 +3,7 @@ name: "Fieldmaster Emberath"
 note: "War Mode Quartermaster"
 
 locations:
-  z9_valdrakken:
+  09-dragonflight/valdrakken:
     - 43.2 42.2
 
 sets:

--- a/data/_shared/vendor/09-dragonflight/valdrakken/fieldmaster_emberath.yml
+++ b/data/_shared/vendor/09-dragonflight/valdrakken/fieldmaster_emberath.yml
@@ -1,0 +1,319 @@
+id: 197553
+name: "Fieldmaster Emberath"
+note: "War Mode Quartermaster"
+
+locations:
+  z9_valdrakken:
+    - 43.2 42.2
+
+sets:
+  - name: "Armor - Cloth"
+    range: 9 1
+
+  - name: "Armor - Leather"
+    range: 9
+
+  - name: "Armor - Mail"
+    range: 9
+
+  - name: "Armor - Plate"
+    range: 9
+
+  - name: "Weapons"
+    range: -1
+
+sells:
+  - type: toy
+    id: 202021 # Breaker's Flag of Victory
+    costs:
+      2123: 1500
+
+  - type: transmog
+    id: 198568 # Drakebreaker's Hood [cloth head]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198572 # Drakebreaker's Shoulderpads [cloth shoulders]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198961 # Drakebreaker's Cloak [cloth set cloak]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198565 # Drakebreaker's Vestment [cloth chest]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198571 # Drakebreaker's Cuffs [cloth wrists]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198567 # Drakebreaker's Gloves [cloth hands]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198570 # Drakebreaker's Cord [cloth waist]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198569 # Drakebreaker's Leggings [cloth legs]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198566 # Drakebreaker's Boots [cloth feet]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198575 # Drakebreaker's Cowl [leather head]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198580 # Drakebreaker's Epaulets [leather shoulders]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198962 # Drakebreaker's Shroud [leather set cloak]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198579 # Drakebreaker's Vest [leather chest]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198578 # Drakebreaker's Bindings [leather wrists]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198574 # Drakebreaker's Handguards [leather hands]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198577 # Drakebreaker's Sash [leather waist]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198576 # Drakebreaker's Breeches [leather legs]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198573 # Drakebreaker's Waders [leather feet]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198592 # Drakebreaker's Coif [mail head]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198594 # Drakebreaker's Shoulderguards [mail shoulders]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198959 # Drakebreaker's Wrap [mail set cloak]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198589 # Drakebreaker's Chestguard [mail chest]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198596 # Drakebreaker's Bracers [mail wrists]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198591 # Drakebreaker's Grips [mail hands]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198595 # Drakebreaker's Cinch [mail waist]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198593 # Drakebreaker's Greaves [mail legs]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198590 # Drakebreaker's Striders [mail feet]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198581 # Drakebreaker's Helm [plate head]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198586 # Drakebreaker's Mantle [plate shoulders]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198960 # Drakebreaker's Cape [plate set cloak]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198582 # Drakebreaker's Breastplate [plate chest]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198588 # Drakebreaker's Armplates [plate wrists]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198584 # Drakebreaker's Gauntlets [plate hands]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 198587 # Drakebreaker's Girdle [plate waist]
+    costs:
+      2123: 200
+
+  - type: transmog
+    id: 198585 # Drakebreaker's Legguards [plate legs]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 198583 # Drakebreaker's Sabatons [plate feet]
+    costs:
+      2123: 350
+
+  - type: transmog
+    id: 199079 # Drakebreaker's Horn [off-hand]
+    costs:
+      2123: 300
+
+  - type: transmog
+    id: 199089 # Drakebreaker's Bulwark [shield]
+    costs:
+      2123: 400
+
+  - type: transmog
+    id: 199070 # Drakebreaker's Cleaver [1h str axe]
+    costs:
+      2123: 400
+
+  - type: transmog
+    id: 199072 # Drakebreaker's Hacker [1h agi axe]
+    costs:
+      2123: 400
+
+  - type: transmog
+    id: 199071 # Drakebreaker's Hatchet [1h int axe]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 199095 # Drakebreaker's Crusher [1h str mace]
+    costs:
+      2123: 400
+
+  - type: transmog
+    id: 199088 # Drakebreaker's Cudgel [1h agi mace]
+    costs:
+      2123: 400
+
+  - type: transmog
+    id: 199096 # Drakebreaker's Mace [1h int mace]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 199094 # Drakebreaker's Mallet [1h agi mace]
+    costs:
+      2123: 400
+
+  - type: transmog
+    id: 199087 # Drakebreaker's Maul [1h str mace]
+    costs:
+      2123: 400
+
+  - type: transmog
+    id: 199086 # Drakebreaker's Scepter [1h int mace]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 199084 # Drakebreaker's Broadsword [2h int sword]
+    costs:
+      2123: 800
+
+  - type: transmog
+    id: 199085 # Drakebreaker's Greatsword [2h str sword]
+    costs:
+      2123: 800
+
+  - type: transmog
+    id: 199077 # Drakebreaker's Dagger [int dagger]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 199078 # Drakebreaker's Shiv [agi dagger]
+    costs:
+      2123: 400
+
+  - type: transmog
+    id: 199093 # Drakebreaker's Rod [wand]
+    costs:
+      2123: 500
+
+  - type: transmog
+    id: 199076 # Drakebreaker's Glaive [warglaive]
+    costs:
+      2123: 400
+
+  - type: transmog
+    id: 199090 # Drakebreaker's Impaler [polearm]
+    costs:
+      2123: 800
+
+  - type: transmog
+    id: 199091 # Drakebreaker's Javelin [polearm]
+    costs:
+      2123: 800
+
+  - type: transmog
+    id: 199082 # Drakebreaker's Pole [staff]
+    costs:
+      2123: 800
+
+  - type: transmog
+    id: 199081 # Drakebreaker's Staff [staff]
+    costs:
+      2123: 800
+
+  - type: transmog
+    id: 199075 # Drakebreaker's Heartseeker [gun]
+    costs:
+      2123: 800

--- a/data/_shared/vendor/09-dragonflight/valdrakken/fieldmaster_emberath.yml
+++ b/data/_shared/vendor/09-dragonflight/valdrakken/fieldmaster_emberath.yml
@@ -1,26 +1,31 @@
 id: 197553
 name: "Fieldmaster Emberath"
-note: "War Mode Quartermaster"
+note: "War Mode Vendor"
 
 locations:
   09-dragonflight/valdrakken:
     - 43.2 42.2
 
 sets:
-  - name: "Armor - Cloth"
+  - name: "War Mode Cloth Set"
     range: 9 1
+    sortKey: "ps11"
 
-  - name: "Armor - Leather"
+  - name: "War Mode Leather Set"
     range: 9
+    sortKey: "ps12"
 
-  - name: "Armor - Mail"
+  - name: "War Mode Mail Set"
     range: 9
+    sortKey: "ps13"
 
-  - name: "Armor - Plate"
+  - name: "War Mode Plate Set"
     range: 9
+    sortKey: "ps14"
 
-  - name: "Weapons"
+  - name: "War Mode Weapons"
     range: -1
+    sortKey: "ps15"
 
 sells:
   - type: toy


### PR DESCRIPTION
Valdrakken is currently internally known as "09-dragonflight/valdrakken" instead of "z9_valdrakken", making these under the assumption that'll be changed.