### PR TITLE
Create pakak.yml

### DIFF
--- a/data/_shared/vendor/09-dragonflight/valdrakken/pakak.yml
+++ b/data/_shared/vendor/09-dragonflight/valdrakken/pakak.yml
@@ -1,0 +1,14 @@
+id: 187783
+name: "Pakak"
+
+locations:
+  valdrakken:
+    - 44 74.4
+
+sells:
+  - type: pet
+    id: 3303 # Mallard Duckling
+    costs:
+      1197788: 1
+      1197789: 1
+      1197792: 3

--- a/data/_shared/vendor/09-dragonflight/valdrakken/pakak.yml
+++ b/data/_shared/vendor/09-dragonflight/valdrakken/pakak.yml
@@ -2,7 +2,7 @@ id: 187783
 name: "Pakak"
 
 locations:
-  valdrakken:
+  09-dragonflight/valdrakken:
     - 44 74.4
 
 sells:


### PR DESCRIPTION
Valdrakken is currently internally known as "09-dragonflight/valdrakken" instead of "z9_valdrakken", making these under the assumption that'll be changed.