### PR TITLE
Create rabul.yml

### DIFF
--- a/data/_shared/vendor/09-dragonflight/valdrakken/rabul.yml
+++ b/data/_shared/vendor/09-dragonflight/valdrakken/rabul.yml
@@ -3,7 +3,7 @@ name: "Rabul"
 note: "Artisan's Consortium Quartermaster"
 
 locations:
-  valdrakken:
+  09-dragonflight/valdrakken:
     - 35.4 59.2
 
 sells:

--- a/data/_shared/vendor/09-dragonflight/valdrakken/rabul.yml
+++ b/data/_shared/vendor/09-dragonflight/valdrakken/rabul.yml
@@ -1,0 +1,14 @@
+id: 194057
+name: "Rabul"
+note: "Artisan's Consortium Quartermaster"
+
+locations:
+  valdrakken:
+    - 35.4 59.2
+
+sells:
+  - type: transmog
+    id: 198802 # Artisan's Consortium Tabard [tabard]
+    costs:
+      0: 1052 # Gold
+    reputation: 2544 esteemed


### PR DESCRIPTION
Valdrakken is currently internally known as "09-dragonflight/valdrakken" instead of "z9_valdrakken", making these under the assumption that'll be changed.