### PR TITLE
Add Dreamsurge tasks

### DIFF
--- a/apps/frontend/data/tasks.ts
+++ b/apps/frontend/data/tasks.ts
@@ -199,6 +199,13 @@ export const taskList: Task[] = [
         minimumLevel: 60,
         type: 'multi',
     },
+    {
+        key: 'dfDreamsurges',
+        name: '[DF] Dreamsurges',
+        shortName: 'DS',
+        minimumLevel: 70,
+        type: 'multi',
+    }
 ]
 
 export const taskMap: Record<string, Task> = Object.fromEntries(
@@ -420,5 +427,10 @@ export const multiTaskMap: Record<string, Chore[]> = {
         //     taskKey: 'dfWhenTimeNeedsMending',
         //     taskName: 'When Time Needs Mending',
         // },
+    ],
+    'dfDreamsurges': [
+        minimumLevel: 70,
+        taskKey: 'dfDreamsurge',
+        taskName: 'Dreamsurges'
     ]
 }

--- a/apps/frontend/data/tasks.ts
+++ b/apps/frontend/data/tasks.ts
@@ -338,7 +338,7 @@ export const multiTaskMap: Record<string, Chore[]> = {
         {
             minimumLevel: 70,
             taskKey: 'dfReachStormsChest',
-            taskName: '[FR] Chest of Storms', 
+            taskName: '[FR] Chest of Storms',
         },
     ],
     'dfChores10_1_0': [
@@ -429,8 +429,10 @@ export const multiTaskMap: Record<string, Chore[]> = {
         // },
     ],
     'dfDreamsurges': [
-        minimumLevel: 70,
-        taskKey: 'dfDreamsurge',
-        taskName: 'Dreamsurges'
+        {
+            minimumLevel: 70,
+            taskKey: 'dfDreamsurge',
+            taskName: 'Dreamsurges'
+        }
     ]
 }


### PR DESCRIPTION
I don't have the site running locally yet, I should probably get around to that at some point.  I saw this was already being tracked in the addon, is this all that's necessary to track it in the website?  If anything else is needed I'd be glad to finish it up.

This will be helpful for getting the normal/heroic tier set appearances across alts.