### PR TITLE
fix(playedTime): add left border to match table head

### DIFF
--- a/apps/frontend/components/home/table/row/HomeTableRowPlayedTime.svelte
+++ b/apps/frontend/components/home/table/row/HomeTableRowPlayedTime.svelte
@@ -13,6 +13,7 @@
     td {
         @include cell-width($width-played);
 
+        border-left: 1px solid $border-color;
         text-align: right;
     }
     code {


### PR DESCRIPTION
Adds a border to the `playedTime` column, as it currently is missing this. The table head shows the border, which makes it look a bit weird without the border.

Without border:
![image](https://github.com/ThingEngineering/wowthing-again/assets/9799276/653324e4-dde6-447f-ac88-818e680b4184)


With border: 
![image](https://github.com/ThingEngineering/wowthing-again/assets/9799276/74374e9b-7d0e-4d51-af70-bf012143a7c4)
