### PR TITLE
feat(tasks): create couldget function for the winter veil event

### DIFF
--- a/apps/frontend/data/tasks.ts
+++ b/apps/frontend/data/tasks.ts
@@ -298,6 +298,9 @@ function garrisonCouldGet(char: Character): boolean {
     return userQuestStore.hasAny(char.id, 34586) || userQuestStore.hasAny(char.id, 34378)
 }
 
+function winterVeilCouldGet(char: Character): boolean {
+    return userQuestStore.hasAny(char.id, 36615) || userQuestStore.hasAny(char.id, 36614)
+}
 
 export const multiTaskMap: Record<string, Chore[]> = {
     'holidayDarkmoonFaire': [
@@ -396,21 +399,25 @@ export const multiTaskMap: Record<string, Chore[]> = {
             minimumLevel: 40,
             taskKey: 'merryGrumpus',
             taskName: 'Grumpus',
+            couldGetFunc: winterVeilCouldGet,
         },
         {
             minimumLevel: 40,
             taskKey: 'merryGrumplings',
             taskName: 'Menacing Grumplings',
+            couldGetFunc: winterVeilCouldGet,
         },
         {
             minimumLevel: 40,
             taskKey: 'merryPresents',
             taskName: 'What Horrible Presents!',
+            couldGetFunc: winterVeilCouldGet,
         },
         {
             minimumLevel: 40,
             taskKey: 'merryChildren',
             taskName: 'Where Are the Children?',
+            couldGetFunc: winterVeilCouldGet,
         },
     ],
     'wodGarrison': [
@@ -532,7 +539,7 @@ export const multiTaskMap: Record<string, Chore[]> = {
         {
             minimumLevel: 70,
             taskKey: 'dfReachStormsChest',
-            taskName: '[FR] Chest of Storms', 
+            taskName: '[FR] Chest of Storms',
         },
     ],
     'dfChores10_1_0': [


### PR DESCRIPTION
4 of the 5 winter veil quests require a level 3 garrison.
Adding a CouldGet function for those to increase visibility of which char still can do the quests without the need to upgrade the garrison.