### PR TITLE
fix(tasks): add minimumlevel to garrison invasions, change requirement to level 2 garrison

### DIFF
--- a/apps/frontend/data/tasks.ts
+++ b/apps/frontend/data/tasks.ts
@@ -295,7 +295,7 @@ export const taskMap: Record<string, Task> = Object.fromEntries(
 
 
 function garrisonCouldGet(char: Character): boolean {
-    return userQuestStore.hasAny(char.id, 34586) || userQuestStore.hasAny(char.id, 34378)
+    return userQuestStore.hasAny(char.id, 36592) || userQuestStore.hasAny(char.id, 36567)
 }
 
 
@@ -418,21 +418,25 @@ export const multiTaskMap: Record<string, Chore[]> = {
             taskKey: 'invasionBronze',
             taskName: '{item:120320}', // Invader's Abandoned Sack
             couldGetFunc: garrisonCouldGet,
+            minimumLevel: 10,
         },
         {
             taskKey: 'invasionSilver',
             taskName: '{item:120319}', // Invader's Damaged Cache
             couldGetFunc: garrisonCouldGet,
+            minimumLevel: 10,
         },
         {
             taskKey: 'invasionGold',
             taskName: '{item:116980}', // Invader's Forgotten Treasure
             couldGetFunc: garrisonCouldGet,
+            minimumLevel: 10,
         },
         {
             taskKey: 'invasionPlatinum',
             taskName: '{item:122163}', // Routed Invader's Crate of Spoils
             couldGetFunc: garrisonCouldGet,
+            minimumLevel: 10,
         },
     ],
     'dfCatchRelease': [


### PR DESCRIPTION
Added the `minimumlevel` attributes to each tasks, as it would otherwise display only `---` for sub max-level chars.
Also change the CouldGet function to look for a level 2 garrison, as that's the requirement to start an invasion.

Theoretically a char doesn't need a garrison to get the rewards, as they could be invited, to start a invasion yourself it might be required to be level 40 (max level of expansion).