### PR TITLE
feat(tasks): split up quest '...You're a Mean One' by level

### DIFF
--- a/apps/frontend/components/tooltips/task/TooltipTaskHead.svelte
+++ b/apps/frontend/components/tooltips/task/TooltipTaskHead.svelte
@@ -9,7 +9,7 @@
     import { QuestStatus } from '@/enums/quest-status'
     import { lazyStore, timeStore, userQuestStore, userStore } from '@/stores'
     import { activeView } from '@/shared/stores/settings'
-    
+
     export let taskName: string
 
     let completed: number
@@ -35,7 +35,7 @@
                 multiTaskMap[taskName],
                 (multiTask) => disabledChores.indexOf(multiTask.taskKey) >= 0
             ).map((multi) => [multi.taskKey, multi.taskName, { 0: 0, 1: 0, 2: 0, 3: 0 }])
-            
+
             for (let i = 0; i < multiStats.length; i++) {
                 multiMap[multiStats[i][1]] = i
             }
@@ -50,6 +50,7 @@
 
             if (
                 character.level >= (task?.minimumLevel || Constants.characterMaxLevel) &&
+                character.level <= (task?.maximumLevel || Constants.characterMaxLevel) &&
                 (
                     !task?.requiredQuestId ||
                     $userQuestStore.characters[character.id]?.quests?.has(task.requiredQuestId)
@@ -66,7 +67,7 @@
                 if (task.type === 'multi') {
                     const { chores: charChores } = $lazyStore.characters[characterId]
                     const taskChores = charChores?.[taskName]
-                    
+
                     if (taskName !== 'dfProfessionWeeklies') {
                         for (const choreTask of (taskChores?.tasks || [])) {
                             multiStats[multiMap[choreTask.name]][2][choreTask.status]++

--- a/apps/frontend/data/tasks.ts
+++ b/apps/frontend/data/tasks.ts
@@ -391,9 +391,15 @@ export const multiTaskMap: Record<string, Chore[]> = {
     ],
     'holidayWinterVeil': [
         {
-            minimumLevel: 30,
+            minimumLevel: 60,
             taskKey: 'meanOne',
             taskName: "...You're a Mean One",
+        },
+        {
+            minimumLevel: 30,
+            maximumLevel: 59,
+            taskKey: 'meanOneLowLevel',
+            taskName: `...You're a Mean One (<${Constants.characterMaxLevel - 10})`,
         },
         {
             minimumLevel: 40,

--- a/apps/frontend/data/tasks.ts
+++ b/apps/frontend/data/tasks.ts
@@ -398,7 +398,7 @@ export const multiTaskMap: Record<string, Chore[]> = {
         {
             minimumLevel: 30,
             maximumLevel: 59,
-            taskKey: 'meanOneLowLevel',
+            taskKey: 'meanOneSplit',
             taskName: `...You're a Mean One (<${Constants.characterMaxLevel - 10})`,
         },
         {

--- a/apps/frontend/stores/lazy/character.ts
+++ b/apps/frontend/stores/lazy/character.ts
@@ -101,6 +101,10 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                             continue
                         }
 
+                        if (choreTask.taskKey.endsWith("Split")) {
+                            choreTask.taskKey = choreTask.taskKey.slice(0, -5);
+                        }
+
                         const charTask = new LazyCharacterChoreTask(
                             stores.userQuestData.characters[character.id]?.progressQuests?.[choreTask.taskKey]
                         )

--- a/apps/frontend/stores/lazy/character.ts
+++ b/apps/frontend/stores/lazy/character.ts
@@ -81,6 +81,9 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                 if (character.level < (task.minimumLevel || Constants.characterMaxLevel)) {
                     continue
                 }
+                if (character.level > (task.maximumLevel || Constants.characterMaxLevel)) {
+                    continue
+                }
 
                 if (task.type === 'multi') {
                     const charChore = new LazyCharacterChore()
@@ -89,6 +92,9 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                     // ugh
                     for (const choreTask of multiTaskMap[taskName]) {
                         if (character.level < (choreTask.minimumLevel || Constants.characterMaxLevel)) {
+                            continue
+                        }
+                        if (character.level > (choreTask.maximumLevel || Constants.characterMaxLevel)){
                             continue
                         }
                         if (choreTask.couldGetFunc?.(character) === false) {
@@ -134,7 +140,7 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                             ||
                             charTask.statusTexts[0] !== ''
                         )
-            
+
                         if (!charTask.skipped) {
                             charChore.countTotal++
                         }
@@ -146,19 +152,19 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                             charTask.statusTexts = []
                             let haveCount = 0
                             let needCount = 0
-            
+
                             if (taskName === 'dfProfessionWeeklies') {
                                 const professionName = choreTask.taskKey.replace('dfProfession', '').replace('Drop#', '')
                                 const profession = Profession[professionName as keyof typeof Profession]
                                 const professionData = dragonflightProfessionMap[profession]
-                                
+
                                 if (professionData.dropQuests?.length > 0) {
                                     needCount = professionData.dropQuests.length
-            
+
                                     professionData.dropQuests.forEach((drop, index) => {
                                         const dropKey = choreTask.taskKey.replace('#', (index + 1).toString())
                                         const progressQuest = stores.userQuestData.characters[character.id]?.progressQuests?.[dropKey]
-            
+
                                         let statusText = ''
                                         if (progressQuest?.status === QuestStatus.Completed &&
                                             DateTime.fromSeconds(progressQuest.expires) > stores.currentTime) {
@@ -168,15 +174,15 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                                         else {
                                             statusText += '<span class="status-fail">:no:</span>'
                                         }
-                                        
+
                                         statusText += `{item:${drop.itemId}}`
                                         statusText += ` <span class="status-shrug">(${drop.source})</span>`
-            
+
                                         charTask.statusTexts.push(statusText)
                                     })
                                 }
                             }
-            
+
                             if (charTask.statusTexts.length === 0) {
                                 needCount = choreTask.taskName.match(/^(Herbalism|Mining|Skinning):/) ? 6 : 4
                                 for (let dropIndex = 0; dropIndex < needCount; dropIndex++) {
@@ -187,7 +193,7 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                                     }
                                 }
                             }
-            
+
                             if (haveCount === needCount) {
                                 charTask.status = QuestStatus.Completed
                             }
@@ -211,7 +217,7 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                         charTask.name = taskName === 'dfDungeonWeeklies'
                             ? stores.userQuestData.questNames[choreTask.taskKey] || choreTask.taskName
                             : choreTask.taskName
-                        
+
                         if (!charTask.skipped) {
                             if (charTask.status === QuestStatus.Completed) {
                                 charChore.countCompleted++
@@ -220,7 +226,7 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                                 charChore.countStarted++
                             }
                         }
-                    
+
                         charChore.tasks.push(charTask)
                     }
 
@@ -234,7 +240,7 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                         status: undefined,
                         text: undefined,
                     }
-                    
+
                     if (charTask.quest) {
                         const expires = DateTime.fromSeconds(charTask.quest.expires)
                         if (forcedReset[questKey]) {
@@ -249,14 +255,14 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                                 charTask.quest.status = QuestStatus.NotStarted
                             }
                         }
-        
+
                         if (charTask.quest.status === QuestStatus.Completed) {
                             charTask.status = 'success'
                             charTask.text = 'Done'
                         }
                         else if (charTask.quest.status === QuestStatus.InProgress) {
                             charTask.status = 'shrug'
-                            
+
                             let objectives = charTask.quest.objectives || []
                             if (objectives.length === 1) {
                                 const objective = charTask.quest.objectives[0]
@@ -269,7 +275,7 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
                                 else {
                                     charTask.text = `${Math.floor(Math.min(objective.have, objective.need) / objective.need * 100)} %`
                                 }
-        
+
                                 if (objective.have === objective.need) {
                                     charTask.status = `${charTask.status} status-turn-in`
                                 }
@@ -285,16 +291,16 @@ export function doCharacters(stores: LazyStores): Record<string, LazyCharacter> 
 
                                 const averagePercent = objectives
                                     .reduce((a, b) => (a + (Math.min(b.have, b.need) / b.need)), 0) / objectives.length
-        
+
                                 charTask.text = `${Math.floor(averagePercent * 100)} %`
-        
+
                                 if (averagePercent >= 1) {
                                     charTask.status = `${charTask.status} status-turn-in`
                                 }
                             }
                         }
                     }
-        
+
                     if (charTask.status === undefined) {
                         charTask.status = 'fail'
                         charTask.text = 'Get!'
@@ -340,7 +346,7 @@ function checkCooldowns(
                         have = 0
                     }
                 }
-                
+
                 ret.have += have
                 ret.total++
                 if (have) {

--- a/apps/frontend/types/tasks.ts
+++ b/apps/frontend/types/tasks.ts
@@ -3,6 +3,7 @@ import type { Character } from './character'
 
 export type Task = {
     minimumLevel?: number
+    maximumLevel?: number
     requiredQuestId?: number
     key: string
     name: string
@@ -12,6 +13,7 @@ export type Task = {
 
 export type Chore = {
     minimumLevel?: number,
+    maximumLevel?: number,
     taskKey: string,
     taskName: string,
     canGetFunc?: (char: Character) => string


### PR DESCRIPTION
The quest reward for the quest '...You're a Mean One' differs from low level chars (30-59) & 60+ chars.

The chest from the low level quests doesn't drop the toys / pets you want to farm and is not really considered worth it, so I split it up into two different tasks that can be selected inside wowthing.

With this PR I also introduced the maximumLevel setting & taskKey modification (removes 'Split' at the end), because both quests have the same Id's, a character cannot do the quest twice a day by leveling up to 60.
Having both chores with the same taskKey would introduce a bug in the settings window as both tasks would only toggle the first task.
Not sure if you like this implementation with the 'Split' suffix, or if we should rewrite portion of the MultiTask settings to allow for multiple tasks with the same taskKey (or maybe even a seperate `id` parameter in the chores list).

_Sorry for all the whitespace removal, my editor keeps removing them on save_